### PR TITLE
Small fixes and tidying

### DIFF
--- a/src/cli/instance/commands/install.js
+++ b/src/cli/instance/commands/install.js
@@ -1,7 +1,6 @@
 // @flow
 import { type Argv } from 'yargs';
-import {
-  createCommandHandler,
+import createCommandHandler, {
   type CommandHandlerDefinition,
 } from '../../util/commandHandler';
 import MinecraftReleasesFile from '../../../versions/MinecraftReleaseListFile';

--- a/src/cli/instance/commands/start.js
+++ b/src/cli/instance/commands/start.js
@@ -1,7 +1,6 @@
 // @flow
 import { type Argv } from 'yargs';
-import {
-  createCommandHandler,
+import createCommandHandler, {
   type CommandHandlerDefinition,
 } from '../../util/commandHandler';
 

--- a/src/cli/instance/commands/status.js
+++ b/src/cli/instance/commands/status.js
@@ -1,6 +1,5 @@
 // @flow
-import {
-  createCommandHandler,
+import createCommandHandler, {
   type CommandHandlerDefinition,
 } from '../../util/commandHandler';
 

--- a/src/cli/instance/commands/stop.js
+++ b/src/cli/instance/commands/stop.js
@@ -1,7 +1,6 @@
 // @flow
 import { type Argv } from 'yargs';
-import {
-  createCommandHandler,
+import createCommandHandler, {
   type CommandHandlerDefinition,
 } from '../../util/commandHandler';
 

--- a/src/cli/instance/commands/upgrade.js
+++ b/src/cli/instance/commands/upgrade.js
@@ -1,7 +1,6 @@
 // @flow
 import { type Argv } from 'yargs';
-import {
-  createCommandHandler,
+import createCommandHandler, {
   type CommandHandlerDefinition,
 } from '../../util/commandHandler';
 import MinecraftReleasesFile from '../../../versions/MinecraftReleaseListFile';

--- a/src/cli/util/commandHandler.js
+++ b/src/cli/util/commandHandler.js
@@ -23,8 +23,7 @@ export type CommandHandlerDefinition<T, U> = {
   renderError?: ErrorRenderer,
 };
 
-// eslint-disable-next-line import/prefer-default-export
-export function createCommandHandler<T: Object, U: Object>({
+export default function createCommandHandler<T: Object, U: Object>({
   setup,
   render,
   renderError,
@@ -39,7 +38,6 @@ export function createCommandHandler<T: Object, U: Object>({
     const result = await setup(argv, instance);
 
     if (argv.json) {
-      // eslint-disable-next-line no-console
       return JSON.stringify(result, null, 2);
     }
 

--- a/src/cli/util/commandHandler.js
+++ b/src/cli/util/commandHandler.js
@@ -5,14 +5,9 @@ import MinecraftInstance from '../../instance/Instance';
 
 type ErrorRenderer = (error: Error, argv: *) => string | Array<?string>;
 const defaultErrorRenderer: ErrorRenderer = (error: Error) => `Something went wrong:\n\t${error.message}`;
-const logToConsole = (output: string | Array<?string>) => {
-  if (output instanceof Array) {
-    // eslint-disable-next-line no-console
-    output.filter(Boolean).forEach(line => console.log(line));
-  } else {
-    // eslint-disable-next-line no-console
-    console.log(output);
-  }
+const logToConsole = (result: string | Array<?string>) => {
+  const output = result instanceof Array ? result.join('\n') : result;
+  process.stdout.write(`${output}\n`);
 };
 
 export type CommandHandlerDefinition<T, U> = {


### PR DESCRIPTION
Remove the need for all but 1 `eslint-disable`, by:
 - Making `createCommandHandler` the default export of its module
 - Simplifying the `logToConsole` function, using `process.stdout.write`